### PR TITLE
Prevent System.exit() from being called

### DIFF
--- a/src/org/python/core/PyJavaType.java
+++ b/src/org/python/core/PyJavaType.java
@@ -1354,6 +1354,10 @@ public class PyJavaType extends PyType {
                 return true;
             }
         }
+        // prevent java.lang.System.exit() from being called
+        if ("java.lang.System".equals(meth.getDeclaringClass().getCanonicalName()) && "exit".equals(meth.getName())) {
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
This is achieved by excluding the method from being added to the dictionary.

The result is as follows:
```
>>> from java.lang import System
>>> System.exit(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'java.lang.System' has no attribute 'exit'
>>> 
```